### PR TITLE
Fix 404 error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { installDependencies, addDependency } from 'nypm'
 import { relative } from 'pathe'
 import { downloadTemplate } from 'giget'
 
-const templateUrl = 'github:dev-cetus/typescript-nodejs-template#master'
+const templateUrl = 'github:dev-cetus/typescript-nodejs-template#develop'
 
 async function main() {
     consola.info('Welcome to the TypeScript-Node.js project creation assistant!')


### PR DESCRIPTION
Fixes the "Failed to download https://api.github.com/repos/dev-cetus/typescript-nodejs-template/tarball/master: 404 Not Found" error when cloning the dev-cetus/typescript-nodejs-template repository